### PR TITLE
Add WWE Universe tracker web app

### DIFF
--- a/home.html
+++ b/home.html
@@ -141,6 +141,7 @@
                     <li><a href="http://ist226w01swareham.atwebpages.com/chapter8/tutorial/cp_royal.html">Cinema Penguin</a></li>
                     <li><a href="http://ist226w01swareham.atwebpages.com/chapter9/tny_clock.html">Tulsa's New Year's Bash</a></li>
                     <li><a href="http://ist226w01swareham.atwebpages.com/chapter10/tutorial/lht_august.html">Lyman Hall Theater</a></li>
+                    <li><a href="universe-tracker.html">WWE 2K25 Universe Tracker</a></li>
               </ul>
            </div>
 <div id="contactForm" class="form">

--- a/universe-tracker.css
+++ b/universe-tracker.css
@@ -1,0 +1,268 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --surface: #1e293b;
+  --surface-alt: rgba(15, 23, 42, 0.85);
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --accent: #f97316;
+  --danger: #ef4444;
+  font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.18), transparent 55%),
+    radial-gradient(circle at bottom, rgba(244, 114, 182, 0.18), transparent 45%),
+    var(--bg);
+  color: var(--text);
+}
+
+.page-header {
+  padding: 2.5rem clamp(1rem, 5vw, 4rem) 1.5rem;
+  text-align: center;
+  position: sticky;
+  top: 0;
+  backdrop-filter: blur(18px);
+  background-color: rgba(15, 23, 42, 0.82);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  z-index: 10;
+}
+
+.page-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(2rem, 5vw, 3rem);
+  letter-spacing: 1px;
+}
+
+.page-header p {
+  max-width: 52rem;
+  margin: 0 auto 1.5rem;
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+.header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+button,
+.import-label {
+  cursor: pointer;
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.4rem;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  background: linear-gradient(120deg, rgba(249, 115, 22, 0.9), rgba(239, 68, 68, 0.85));
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+button:hover,
+.import-label:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.45);
+}
+
+button:focus-visible,
+.import-label:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.8);
+  outline-offset: 3px;
+}
+
+button.danger {
+  background: linear-gradient(120deg, rgba(239, 68, 68, 0.95), rgba(239, 68, 68, 0.65));
+}
+
+.import-label {
+  position: relative;
+  overflow: hidden;
+}
+
+.import-label input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+main {
+  padding: 0 clamp(1rem, 5vw, 4rem) 4rem;
+  display: grid;
+  gap: 2rem;
+  margin-top: 1.5rem;
+}
+
+.card {
+  background: linear-gradient(160deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.9));
+  border-radius: 1.5rem;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: clamp(1.5rem, 3vw, 2.1rem);
+}
+
+.section-subtitle {
+  margin: 0;
+  color: var(--muted);
+}
+
+.form-grid {
+  display: grid;
+  gap: 0.75rem 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-bottom: 1.25rem;
+}
+
+.form-grid label {
+  font-size: 0.85rem;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.form-grid input,
+.form-grid select,
+.form-grid textarea {
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+  font-size: 1rem;
+}
+
+.form-grid textarea {
+  resize: vertical;
+}
+
+.form-grid button[type="submit"] {
+  grid-column: 1 / -1;
+  justify-self: start;
+  background: linear-gradient(120deg, rgba(56, 189, 248, 0.9), rgba(37, 99, 235, 0.85));
+}
+
+.filter-bar {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 1.25rem;
+}
+
+.filter-bar select {
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: var(--text);
+}
+
+.card-list {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.list-card {
+  position: relative;
+  border-radius: 1.25rem;
+  padding: 1.2rem;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.list-card strong {
+  font-size: 1.05rem;
+}
+
+.list-card span,
+.list-card p {
+  color: var(--muted);
+  margin: 0;
+}
+
+.list-card button.delete-btn {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  padding: 0.35rem 0.65rem;
+  font-size: 0.75rem;
+  background: rgba(239, 68, 68, 0.75);
+  border-radius: 999px;
+}
+
+.summary {
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.summary strong {
+  color: var(--text);
+}
+
+.muted {
+  color: var(--muted);
+  margin: 0;
+}
+
+.page-footer {
+  text-align: center;
+  padding: 2.5rem 1rem 3rem;
+  color: var(--muted);
+}
+
+#toast {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  padding: 1rem 1.5rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.92);
+  color: var(--text);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+@media (max-width: 720px) {
+  .page-header {
+    position: static;
+  }
+
+  .header-actions {
+    flex-direction: column;
+  }
+
+  .card-list {
+    grid-template-columns: 1fr;
+  }
+}

--- a/universe-tracker.html
+++ b/universe-tracker.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WWE 2K25 Universe Tracker</title>
+  <link rel="stylesheet" href="universe-tracker.css">
+</head>
+<body>
+  <header class="page-header">
+    <h1>WWE 2K25 Universe Tracker</h1>
+    <p>Keep tabs on every show, rivalry, champion, and premium live event in your custom Universe mode.</p>
+    <div class="header-actions">
+      <button id="exportData" type="button">Export Universe JSON</button>
+      <label class="import-label" for="importData">Import Save
+        <input id="importData" type="file" accept="application/json">
+      </label>
+      <button id="resetData" class="danger" type="button">Reset All Data</button>
+    </div>
+  </header>
+
+  <main>
+    <section class="card" aria-labelledby="overview-title">
+      <div class="section-header">
+        <h2 id="overview-title">Universe Overview</h2>
+        <p class="section-subtitle">Track the big picture details for your save.</p>
+      </div>
+      <form id="overviewForm" class="form-grid">
+        <label for="universeName">Universe Name</label>
+        <input id="universeName" name="universeName" type="text" placeholder="Multiverse Mayhem">
+
+        <label for="currentWeek">Current Week</label>
+        <input id="currentWeek" name="currentWeek" type="text" placeholder="Week 4, April 2025">
+
+        <label for="owner">General Manager</label>
+        <input id="owner" name="owner" type="text" placeholder="You">
+
+        <label for="overviewNotes">Notes</label>
+        <textarea id="overviewNotes" name="overviewNotes" rows="3" placeholder="Current story beats, seasonal goals, or roster rules."></textarea>
+
+        <button type="submit">Save Overview</button>
+      </form>
+      <div id="overviewSummary" class="summary"></div>
+    </section>
+
+    <section class="card" aria-labelledby="shows-title">
+      <div class="section-header">
+        <h2 id="shows-title">Weekly Shows</h2>
+        <p class="section-subtitle">Document every brand and its broadcast details.</p>
+      </div>
+      <form id="showForm" class="form-grid">
+        <label for="showName">Show Name</label>
+        <input id="showName" name="showName" type="text" required placeholder="Monday Night RAW">
+
+        <label for="showDay">Broadcast Day</label>
+        <input id="showDay" name="showDay" type="text" required placeholder="Mondays">
+
+        <label for="showArena">Arena</label>
+        <input id="showArena" name="showArena" type="text" placeholder="Capitol Wrestling Center">
+
+        <label for="showColor">Brand Color</label>
+        <input id="showColor" name="showColor" type="color" value="#ff0000">
+
+        <label for="showNotes">Show Focus</label>
+        <textarea id="showNotes" name="showNotes" rows="2" placeholder="Main event scene, rivalries, or unique match types."></textarea>
+
+        <button type="submit">Add Show</button>
+      </form>
+      <div id="showsList" class="card-list" aria-live="polite"></div>
+    </section>
+
+    <section class="card" aria-labelledby="roster-title">
+      <div class="section-header">
+        <h2 id="roster-title">Roster</h2>
+        <p class="section-subtitle">Assign Superstars to brands and note their status.</p>
+      </div>
+      <form id="superstarForm" class="form-grid">
+        <label for="superstarName">Superstar</label>
+        <input id="superstarName" name="superstarName" type="text" required placeholder="Cody Rhodes">
+
+        <label for="assignedShow">Assigned Show</label>
+        <select id="assignedShow" name="assignedShow" required>
+          <option value="">Select a show</option>
+        </select>
+
+        <label for="superstarAlignment">Alignment</label>
+        <select id="superstarAlignment" name="superstarAlignment">
+          <option value="Face">Face</option>
+          <option value="Heel">Heel</option>
+          <option value="Tweener">Tweener</option>
+        </select>
+
+        <label for="superstarStatus">Current Status</label>
+        <input id="superstarStatus" name="superstarStatus" type="text" placeholder="#1 Contender, Injured, Manager">
+
+        <label for="superstarNotes">Notes</label>
+        <textarea id="superstarNotes" name="superstarNotes" rows="2" placeholder="Signature moves, storyline beats, factions."></textarea>
+
+        <button type="submit">Add Superstar</button>
+      </form>
+      <div class="filter-bar">
+        <label for="showFilter">Filter by Show:</label>
+        <select id="showFilter">
+          <option value="">All Shows</option>
+        </select>
+      </div>
+      <div id="superstarList" class="card-list" aria-live="polite"></div>
+    </section>
+
+    <section class="card" aria-labelledby="championships-title">
+      <div class="section-header">
+        <h2 id="championships-title">Championships</h2>
+        <p class="section-subtitle">Track title lineages and current champions.</p>
+      </div>
+      <form id="championshipForm" class="form-grid">
+        <label for="titleName">Title Name</label>
+        <input id="titleName" name="titleName" type="text" required placeholder="WWE Championship">
+
+        <label for="titleShow">Defended On</label>
+        <select id="titleShow" name="titleShow" required>
+          <option value="">Select a show</option>
+        </select>
+
+        <label for="currentChampion">Current Champion(s)</label>
+        <input id="currentChampion" name="currentChampion" type="text" required placeholder="Seth Rollins">
+
+        <label for="titleNotes">Reign Details</label>
+        <textarea id="titleNotes" name="titleNotes" rows="2" placeholder="Won at SummerSlam vs. Drew McIntyre"></textarea>
+
+        <button type="submit">Add Championship</button>
+      </form>
+      <div id="championshipList" class="card-list" aria-live="polite"></div>
+    </section>
+
+    <section class="card" aria-labelledby="rivalries-title">
+      <div class="section-header">
+        <h2 id="rivalries-title">Rivalries & Storylines</h2>
+        <p class="section-subtitle">Keep story notes handy for week-to-week booking.</p>
+      </div>
+      <form id="rivalryForm" class="form-grid">
+        <label for="rivalryShow">Show</label>
+        <select id="rivalryShow" name="rivalryShow" required>
+          <option value="">Select a show</option>
+        </select>
+
+        <label for="rivalryParticipants">Participants</label>
+        <input id="rivalryParticipants" name="rivalryParticipants" type="text" required placeholder="Bianca Belair vs. Rhea Ripley">
+
+        <label for="rivalryStart">Started</label>
+        <input id="rivalryStart" name="rivalryStart" type="text" placeholder="Week 1, April 2025">
+
+        <label for="rivalryStatus">Status</label>
+        <select id="rivalryStatus" name="rivalryStatus">
+          <option value="Active">Active</option>
+          <option value="Hiatus">Hiatus</option>
+          <option value="Ended">Ended</option>
+        </select>
+
+        <label for="rivalryNotes">Story Beats</label>
+        <textarea id="rivalryNotes" name="rivalryNotes" rows="2" placeholder="Double count-out finish sets up Steel Cage match."></textarea>
+
+        <button type="submit">Add Rivalry</button>
+      </form>
+      <div id="rivalryList" class="card-list" aria-live="polite"></div>
+    </section>
+
+    <section class="card" aria-labelledby="events-title">
+      <div class="section-header">
+        <h2 id="events-title">Premium Live Events</h2>
+        <p class="section-subtitle">Log card details and memorable results.</p>
+      </div>
+      <form id="eventForm" class="form-grid">
+        <label for="eventName">Event Name</label>
+        <input id="eventName" name="eventName" type="text" required placeholder="SummerSlam">
+
+        <label for="eventDate">Date</label>
+        <input id="eventDate" name="eventDate" type="date">
+
+        <label for="eventLocation">Location</label>
+        <input id="eventLocation" name="eventLocation" type="text" placeholder="Detroit, MI">
+
+        <label for="eventHighlights">Highlights & Results</label>
+        <textarea id="eventHighlights" name="eventHighlights" rows="3" placeholder="Roman Reigns def. Cody Rhodes – Undisputed WWE Title"></textarea>
+
+        <button type="submit">Add Event</button>
+      </form>
+      <div id="eventList" class="card-list" aria-live="polite"></div>
+    </section>
+  </main>
+
+  <footer class="page-footer">
+    <p>Data is saved locally in your browser so you can update the Universe after every session.</p>
+  </footer>
+
+  <dialog id="toast" aria-live="polite"></dialog>
+
+  <script src="universe-tracker.js"></script>
+</body>
+</html>

--- a/universe-tracker.js
+++ b/universe-tracker.js
@@ -1,0 +1,540 @@
+const STORAGE_KEY = "wwe-universe-tracker";
+const data = {
+  overview: {
+    universeName: "",
+    currentWeek: "",
+    owner: "",
+    notes: ""
+  },
+  shows: [],
+  superstars: [],
+  championships: [],
+  rivalries: [],
+  events: []
+};
+
+const state = {
+  filterShow: ""
+};
+
+const elements = {
+  overviewForm: document.getElementById("overviewForm"),
+  overviewSummary: document.getElementById("overviewSummary"),
+  showForm: document.getElementById("showForm"),
+  showsList: document.getElementById("showsList"),
+  superstarForm: document.getElementById("superstarForm"),
+  superstarList: document.getElementById("superstarList"),
+  showFilter: document.getElementById("showFilter"),
+  assignedShow: document.getElementById("assignedShow"),
+  titleShow: document.getElementById("titleShow"),
+  rivalryShow: document.getElementById("rivalryShow"),
+  championshipForm: document.getElementById("championshipForm"),
+  championshipList: document.getElementById("championshipList"),
+  rivalryForm: document.getElementById("rivalryForm"),
+  rivalryList: document.getElementById("rivalryList"),
+  eventForm: document.getElementById("eventForm"),
+  eventList: document.getElementById("eventList"),
+  exportBtn: document.getElementById("exportData"),
+  importInput: document.getElementById("importData"),
+  resetBtn: document.getElementById("resetData"),
+  toast: document.getElementById("toast")
+};
+
+function loadData() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      renderAll();
+      return;
+    }
+    const parsed = JSON.parse(stored);
+    for (const key of Object.keys(data)) {
+      if (parsed[key]) {
+        data[key] = parsed[key];
+      }
+    }
+    renderAll();
+  } catch (error) {
+    console.error("Failed to load data", error);
+    showToast("Could not load saved data. Starting fresh.");
+    renderAll();
+  }
+}
+
+function saveData() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+function renderAll() {
+  renderOverview();
+  renderShows();
+  renderSuperstars();
+  renderChampionships();
+  renderRivalries();
+  renderEvents();
+  syncShowOptions();
+}
+
+function renderOverview() {
+  const { universeName, currentWeek, owner, notes } = data.overview;
+  if (!universeName && !currentWeek && !owner && !notes) {
+    elements.overviewSummary.innerHTML =
+      "<p class=\"muted\">Save an overview to see it here.</p>";
+    return;
+  }
+
+  elements.overviewSummary.innerHTML = `
+    <p><strong>${escapeHtml(universeName || "Unnamed Universe")}</strong></p>
+    <p><strong>Week:</strong> ${escapeHtml(currentWeek || "TBD")}</p>
+    <p><strong>GM:</strong> ${escapeHtml(owner || "")}</p>
+    ${notes ? `<p>${escapeHtml(notes)}</p>` : ""}
+  `;
+}
+
+function renderShows() {
+  if (!data.shows.length) {
+    elements.showsList.innerHTML = `<p class="muted">Add your first show to begin tracking rosters.</p>`;
+    return;
+  }
+
+  elements.showsList.innerHTML = data.shows
+    .map(
+      (show, index) => `
+        <article class="list-card" style="border-top: 5px solid ${show.color};">
+          <button type="button" class="delete-btn" data-type="show" data-index="${index}">Remove</button>
+          <strong>${escapeHtml(show.name)}</strong>
+          <span>${escapeHtml(show.day)} ${show.arena ? `• ${escapeHtml(show.arena)}` : ""}</span>
+          ${show.notes ? `<p>${escapeHtml(show.notes)}</p>` : ""}
+        </article>
+      `
+    )
+    .join("");
+}
+
+function renderSuperstars() {
+  const filtered = state.filterShow
+    ? data.superstars.filter((star) => star.show === state.filterShow)
+    : data.superstars;
+
+  if (!filtered.length) {
+    elements.superstarList.innerHTML = `<p class="muted">${
+      data.superstars.length
+        ? "No superstars for this filter yet."
+        : "Add superstars to build your roster."
+    }</p>`;
+    return;
+  }
+
+  elements.superstarList.innerHTML = filtered
+    .map((star, index) => {
+      const globalIndex = data.superstars.indexOf(star);
+      return `
+        <article class="list-card" data-show="${escapeHtml(star.show)}">
+          <button type="button" class="delete-btn" data-type="superstar" data-index="${globalIndex}">Remove</button>
+          <strong>${escapeHtml(star.name)}</strong>
+          <span>${escapeHtml(star.show)} • ${escapeHtml(star.alignment)}</span>
+          ${star.status ? `<span>Status: ${escapeHtml(star.status)}</span>` : ""}
+          ${star.notes ? `<p>${escapeHtml(star.notes)}</p>` : ""}
+        </article>
+      `;
+    })
+    .join("");
+}
+
+function renderChampionships() {
+  if (!data.championships.length) {
+    elements.championshipList.innerHTML = `<p class="muted">Add a title to track your champions.</p>`;
+    return;
+  }
+
+  elements.championshipList.innerHTML = data.championships
+    .map(
+      (title, index) => `
+        <article class="list-card">
+          <button type="button" class="delete-btn" data-type="championship" data-index="${index}">Remove</button>
+          <strong>${escapeHtml(title.name)}</strong>
+          <span>${escapeHtml(title.show)} • Current: ${escapeHtml(title.champion)}</span>
+          ${title.notes ? `<p>${escapeHtml(title.notes)}</p>` : ""}
+        </article>
+      `
+    )
+    .join("");
+}
+
+function renderRivalries() {
+  if (!data.rivalries.length) {
+    elements.rivalryList.innerHTML = `<p class="muted">Log your first storyline to keep the momentum rolling.</p>`;
+    return;
+  }
+
+  elements.rivalryList.innerHTML = data.rivalries
+    .map(
+      (rivalry, index) => `
+        <article class="list-card">
+          <button type="button" class="delete-btn" data-type="rivalry" data-index="${index}">Remove</button>
+          <strong>${escapeHtml(rivalry.participants)}</strong>
+          <span>${escapeHtml(rivalry.show)} • ${escapeHtml(rivalry.status)}</span>
+          ${rivalry.start ? `<span>Started: ${escapeHtml(rivalry.start)}</span>` : ""}
+          ${rivalry.notes ? `<p>${escapeHtml(rivalry.notes)}</p>` : ""}
+        </article>
+      `
+    )
+    .join("");
+}
+
+function renderEvents() {
+  if (!data.events.length) {
+    elements.eventList.innerHTML = `<p class="muted">No premium live events logged yet.</p>`;
+    return;
+  }
+
+  elements.eventList.innerHTML = data.events
+    .map(
+      (event, index) => `
+        <article class="list-card">
+          <button type="button" class="delete-btn" data-type="event" data-index="${index}">Remove</button>
+          <strong>${escapeHtml(event.name)}</strong>
+          ${event.date ? `<span>${escapeHtml(formatDate(event.date))}</span>` : ""}
+          ${event.location ? `<span>${escapeHtml(event.location)}</span>` : ""}
+          ${event.highlights ? `<p>${escapeHtml(event.highlights)}</p>` : ""}
+        </article>
+      `
+    )
+    .join("");
+}
+
+function syncShowOptions() {
+  const options = ['<option value="">Select a show</option>']
+    .concat(data.shows.map((show) => `<option value="${escapeHtml(show.name)}">${escapeHtml(show.name)}</option>`))
+    .join("");
+
+  elements.assignedShow.innerHTML = options;
+  elements.titleShow.innerHTML = options;
+  elements.rivalryShow.innerHTML = options;
+
+  const filterOptions = ['<option value="">All Shows</option>']
+    .concat(data.shows.map((show) => `<option value="${escapeHtml(show.name)}">${escapeHtml(show.name)}</option>`))
+    .join("");
+
+  elements.showFilter.innerHTML = filterOptions;
+  if (state.filterShow && !data.shows.find((show) => show.name === state.filterShow)) {
+    state.filterShow = "";
+  }
+}
+
+function addShow(formData) {
+  const show = {
+    name: formData.get("showName").trim(),
+    day: formData.get("showDay").trim(),
+    arena: formData.get("showArena").trim(),
+    color: formData.get("showColor") || "#ffffff",
+    notes: formData.get("showNotes").trim()
+  };
+
+  if (!show.name || !show.day) {
+    showToast("Show name and broadcast day are required.");
+    return;
+  }
+
+  data.shows.push(show);
+  saveData();
+  renderShows();
+  syncShowOptions();
+  showToast(`${show.name} added.`);
+}
+
+function addSuperstar(formData) {
+  const superstar = {
+    name: formData.get("superstarName").trim(),
+    show: formData.get("assignedShow"),
+    alignment: formData.get("superstarAlignment") || "Face",
+    status: formData.get("superstarStatus").trim(),
+    notes: formData.get("superstarNotes").trim()
+  };
+
+  if (!superstar.name || !superstar.show) {
+    showToast("Superstar name and show are required.");
+    return;
+  }
+
+  data.superstars.push(superstar);
+  saveData();
+  renderSuperstars();
+  showToast(`${superstar.name} added to ${superstar.show}.`);
+}
+
+function addChampionship(formData) {
+  const title = {
+    name: formData.get("titleName").trim(),
+    show: formData.get("titleShow"),
+    champion: formData.get("currentChampion").trim(),
+    notes: formData.get("titleNotes").trim()
+  };
+
+  if (!title.name || !title.show || !title.champion) {
+    showToast("Title name, defending show, and champion are required.");
+    return;
+  }
+
+  data.championships.push(title);
+  saveData();
+  renderChampionships();
+  showToast(`${title.name} saved.`);
+}
+
+function addRivalry(formData) {
+  const rivalry = {
+    show: formData.get("rivalryShow"),
+    participants: formData.get("rivalryParticipants").trim(),
+    start: formData.get("rivalryStart").trim(),
+    status: formData.get("rivalryStatus"),
+    notes: formData.get("rivalryNotes").trim()
+  };
+
+  if (!rivalry.show || !rivalry.participants) {
+    showToast("Show and participants are required for a rivalry.");
+    return;
+  }
+
+  data.rivalries.push(rivalry);
+  saveData();
+  renderRivalries();
+  showToast(`Rivalry saved for ${rivalry.show}.`);
+}
+
+function addEvent(formData) {
+  const event = {
+    name: formData.get("eventName").trim(),
+    date: formData.get("eventDate"),
+    location: formData.get("eventLocation").trim(),
+    highlights: formData.get("eventHighlights").trim()
+  };
+
+  if (!event.name) {
+    showToast("Event name is required.");
+    return;
+  }
+
+  data.events.push(event);
+  saveData();
+  renderEvents();
+  showToast(`${event.name} added.`);
+}
+
+function deleteItem(type, index) {
+  if (!data[type] || !data[type][index]) return;
+  const [removed] = data[type].splice(index, 1);
+
+  if (type === "shows" && removed?.name) {
+    const showName = removed.name;
+    data.superstars = data.superstars.filter((star) => star.show !== showName);
+    data.championships = data.championships.filter((title) => title.show !== showName);
+    data.rivalries = data.rivalries.filter((rivalry) => rivalry.show !== showName);
+    if (state.filterShow === showName) {
+      state.filterShow = "";
+    }
+  }
+
+  saveData();
+
+  switch (type) {
+    case "shows":
+      renderShows();
+      renderSuperstars();
+      renderChampionships();
+      renderRivalries();
+      syncShowOptions();
+      break;
+    case "superstars":
+      renderSuperstars();
+      break;
+    case "championships":
+      renderChampionships();
+      break;
+    case "rivalries":
+      renderRivalries();
+      break;
+    case "events":
+      renderEvents();
+      break;
+    default:
+      break;
+  }
+
+  showToast(`${removed?.name || "Item"} removed.`);
+}
+
+function handleDelete(event) {
+  const button = event.target.closest("button.delete-btn");
+  if (!button) return;
+
+  const type = button.dataset.type;
+  const index = Number(button.dataset.index);
+  const map = {
+    show: "shows",
+    superstar: "superstars",
+    championship: "championships",
+    rivalry: "rivalries",
+    event: "events"
+  };
+
+  deleteItem(map[type], index);
+}
+
+function handleFormSubmit(form, handler) {
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const formData = new FormData(form);
+    handler(formData);
+    form.reset();
+  });
+}
+
+function handleOverviewSubmit() {
+  elements.overviewForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const formData = new FormData(elements.overviewForm);
+    data.overview.universeName = formData.get("universeName").trim();
+    data.overview.currentWeek = formData.get("currentWeek").trim();
+    data.overview.owner = formData.get("owner").trim();
+    data.overview.notes = formData.get("overviewNotes").trim();
+    saveData();
+    renderOverview();
+    showToast("Overview updated.");
+  });
+}
+
+function setupFilter() {
+  elements.showFilter.addEventListener("change", (event) => {
+    state.filterShow = event.target.value;
+    renderSuperstars();
+  });
+}
+
+function handleExport() {
+  elements.exportBtn.addEventListener("click", async () => {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(data, null, 2));
+      showToast("Universe copied to clipboard as JSON!");
+    } catch (error) {
+      console.error(error);
+      showToast("Copy failed. JSON downloaded instead.");
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `${data.overview.universeName || "wwe-universe"}.json`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    }
+  });
+}
+
+function handleImport() {
+  elements.importInput.addEventListener("change", async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      const imported = JSON.parse(text);
+      for (const key of Object.keys(data)) {
+        if (imported[key] !== undefined) {
+          data[key] = imported[key];
+        }
+      }
+      saveData();
+      renderAll();
+      showToast("Universe data imported!");
+    } catch (error) {
+      console.error("Import failed", error);
+      showToast("Could not import file. Make sure it's a valid export.");
+    } finally {
+      event.target.value = "";
+    }
+  });
+}
+
+function handleReset() {
+  elements.resetBtn.addEventListener("click", () => {
+    if (!confirm("Reset all saved Universe data? This cannot be undone.")) return;
+    for (const key of Object.keys(data)) {
+      if (Array.isArray(data[key])) {
+        data[key] = [];
+      } else {
+        data[key] = { universeName: "", currentWeek: "", owner: "", notes: "" };
+      }
+    }
+    state.filterShow = "";
+    saveData();
+    renderAll();
+    showToast("Universe reset.");
+  });
+}
+
+function showToast(message) {
+  elements.toast.textContent = message;
+  elements.toast.setAttribute("open", "");
+  setTimeout(() => {
+    elements.toast.removeAttribute("open");
+  }, 2800);
+}
+
+function formatDate(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric"
+  });
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function hydrateForms() {
+  elements.overviewForm.universeName.value = data.overview.universeName;
+  elements.overviewForm.currentWeek.value = data.overview.currentWeek;
+  elements.overviewForm.owner.value = data.overview.owner;
+  elements.overviewForm.overviewNotes.value = data.overview.notes;
+}
+
+function hydrateSelects() {
+  syncShowOptions();
+  elements.showFilter.value = state.filterShow;
+}
+
+function init() {
+  loadData();
+  hydrateForms();
+  hydrateSelects();
+
+  handleOverviewSubmit();
+  handleFormSubmit(elements.showForm, addShow);
+  handleFormSubmit(elements.superstarForm, addSuperstar);
+  handleFormSubmit(elements.championshipForm, addChampionship);
+  handleFormSubmit(elements.rivalryForm, addRivalry);
+  handleFormSubmit(elements.eventForm, addEvent);
+
+  elements.showsList.addEventListener("click", handleDelete);
+  elements.superstarList.addEventListener("click", handleDelete);
+  elements.championshipList.addEventListener("click", handleDelete);
+  elements.rivalryList.addEventListener("click", handleDelete);
+  elements.eventList.addEventListener("click", handleDelete);
+
+  setupFilter();
+  handleExport();
+  handleImport();
+  handleReset();
+}
+
+init();


### PR DESCRIPTION
## Summary
- add a dedicated WWE 2K25 Universe tracker page with sections for shows, roster, championships, rivalries, and premium live events
- implement localStorage-powered CRUD logic, JSON import/export, and reset workflows for the tracker
- create a neon-inspired UI theme and link the new tool from the home page navigation

## Testing
- Manual verification via `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_68dd71b5be78832cb24a0124c16839cd